### PR TITLE
add Tab Order comment block parameter

### DIFF
--- a/data/comment-block-parameters/tab_order.md
+++ b/data/comment-block-parameters/tab_order.md
@@ -1,4 +1,4 @@
-## Order
+## Tab Order
 
 The sort order of this settings tab. 
 
@@ -9,5 +9,5 @@ Piklist Parts: settings
 
 Example:
 ```
-order: 4
+Tab Order: 4
 ```

--- a/data/comment-block-parameters/tab_order.md
+++ b/data/comment-block-parameters/tab_order.md
@@ -1,0 +1,13 @@
+## Order
+
+The sort order of this settings tab. 
+
+Piklist Parts: settings
+
+* Input:  numeric
+* Returns:  numeric
+
+Example:
+```
+order: 4
+```


### PR DESCRIPTION
added a  comment block parameter for Tab Order

thanks to @jasontheadams for [this ancient tip](https://piklist.com/support/topic/add-settings-tab-order-to-settings/)