### PR TITLE
Fixed typo in heading

### DIFF
--- a/layouts/shortcodes/data/field-parameters/required.md
+++ b/layouts/shortcodes/data/field-parameters/required.md
@@ -1,4 +1,4 @@
-## request_value
+## required
 
 Make a field required. If this field is not filled in the form will not save.
 


### PR DESCRIPTION
The heading was set to "request_value" when it should be "required"